### PR TITLE
Implement prompt search

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,11 @@
             <p class="max-w-2xl mx-auto text-lg text-gray-500 mt-4">
                 A curated collection of prompts to help you unlock the full potential of Gemini.
             </p>
+            <div class="max-w-lg mx-auto mt-6 flex">
+                <input id="search-input" type="text" placeholder="Search prompts..." class="flex-1 p-2 border border-gray-300 rounded-l" />
+                <button id="clear-search-btn" class="p-2 bg-gray-100 border border-gray-300 rounded-r hidden">Clear</button>
+            </div>
+            <p id="search-results-info" class="max-w-lg mx-auto text-sm text-gray-500 mt-2"></p>
         </header>
         <main class="container mx-auto px-4 sm:px-6 lg:px-8 pb-16">
             <!-- Category cards will be injected here by JavaScript -->
@@ -153,6 +158,7 @@
         // --- DATA STRUCTURE ---
         // promptData will be loaded dynamically from prompts.json
         let promptData = null;
+        let allPrompts = [];
 
         // --- DOM ELEMENTS ---
         const homepageView = document.getElementById('homepage-view');
@@ -161,6 +167,9 @@
         const promptDisplayArea = document.getElementById('prompt-display-area');
         const quickLinksSidebar = document.getElementById('quick-links-sidebar');
         const backToHomeBtn = document.getElementById('back-to-home-btn');
+        const searchInput = document.getElementById('search-input');
+        const clearSearchBtn = document.getElementById('clear-search-btn');
+        const searchResultsInfo = document.getElementById('search-results-info');
 
         // --- RENDER FUNCTIONS ---
 
@@ -185,6 +194,27 @@
                     <span class="text-red-500 text-lg">${message}</span>
                 </div>
             `;
+        }
+
+        /**
+         * Builds a flat list of all prompts for searching.
+         * @returns {Array}
+         */
+        function buildAllPrompts() {
+            const list = [];
+            for (const categoryName in promptData) {
+                for (const subCategoryName in promptData[categoryName]) {
+                    const prompts = promptData[categoryName][subCategoryName];
+                    prompts.forEach(p => {
+                        list.push({
+                            ...p,
+                            category: categoryName,
+                            subCategory: subCategoryName
+                        });
+                    });
+                }
+            }
+            return list;
         }
 
         /**
@@ -220,6 +250,60 @@
                 `;
                 categoryCardsContainer.appendChild(card);
             }
+        }
+
+        /**
+         * Filters allPrompts by a search term and displays the results.
+         * @param {string} term
+         */
+        function filterAndDisplayPrompts(term) {
+            const searchTerm = term.trim().toLowerCase();
+            if (!searchTerm) {
+                searchResultsInfo.textContent = '';
+                clearSearchBtn.classList.add('hidden');
+                renderHomepage();
+                return;
+            }
+
+            const results = allPrompts.filter(p =>
+                p.title.toLowerCase().includes(searchTerm) ||
+                p.content.toLowerCase().includes(searchTerm) ||
+                p.category.toLowerCase().includes(searchTerm) ||
+                p.subCategory.toLowerCase().includes(searchTerm)
+            );
+
+            categoryCardsContainer.innerHTML = '';
+
+            if (results.length === 0) {
+                categoryCardsContainer.innerHTML = `<p class="text-center text-gray-500">No results found</p>`;
+            } else {
+                results.forEach(p => {
+                    const card = document.createElement('div');
+                    card.className = 'prompt-block p-6 mb-4';
+                    card.innerHTML = `
+                        <p class="text-sm text-gray-500 mb-1">${p.category} → ${p.subCategory}</p>
+                        <h3 class="text-xl font-semibold mb-2 main-heading">${highlightTerm(p.title, searchTerm)}</h3>
+                        <div class="prompt-display-item p-4 text-gray-700">
+                            <p>${highlightTerm(p.content, searchTerm)}</p>
+                        </div>
+                    `;
+                    categoryCardsContainer.appendChild(card);
+                });
+            }
+
+            searchResultsInfo.textContent = `${results.length} result${results.length !== 1 ? 's' : ''} found`;
+            clearSearchBtn.classList.remove('hidden');
+        }
+
+        /**
+         * Highlights search term within text.
+         * @param {string} text
+         * @param {string} term
+         */
+        function highlightTerm(text, term) {
+            if (!term) return text;
+            const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            return text.replace(new RegExp(escaped, 'gi'), match => `<mark>${match}</mark>`);
         }
 
         /**
@@ -335,6 +419,15 @@
         // Event listener for the "Back" button
         backToHomeBtn.addEventListener('click', showHomepage);
 
+        // Event listeners for search
+        searchInput.addEventListener('input', (e) => {
+            filterAndDisplayPrompts(e.target.value);
+        });
+        clearSearchBtn.addEventListener('click', () => {
+            searchInput.value = '';
+            filterAndDisplayPrompts('');
+        });
+
         // --- INITIAL LOAD ---
         document.addEventListener('DOMContentLoaded', () => {
             renderLoading();
@@ -345,6 +438,7 @@
                 })
                 .then(data => {
                     promptData = data.promptData;
+                    allPrompts = buildAllPrompts();
                     renderHomepage();
                 })
                 .catch(err => {


### PR DESCRIPTION
## Summary
- add search field and clear button to homepage
- parse prompts into an array for search
- implement `filterAndDisplayPrompts` and highlight helper
- add search input event handlers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688af1f59a3c8330b27ac3e4715705f8